### PR TITLE
Example site: correct rendering of subscript, superscript and other raw html markup

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -95,3 +95,9 @@ series = "series"
 
   [services.twitter]
     disableInlineCSS = true
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      # needed to render raw HTML (e.g. <sub>, <sup>, <kbd>, <mark>)
+      unsafe = true


### PR DESCRIPTION
**Example site, page [Markdown Syntax Guide](http://localhost:1313/post/markdown-syntax/):**

Last chapter `Other Elements — abbr, sub, sup, kbd, mark`

Terms like H<sub>2</sub>O are rendered incorrectly since by default, hugo's default renderer `goldmark` scrubs raw html tags for security reasons (see hugo's [documentation](https://gohugo.io/getting-started/configuration-markup#goldmark) on this topic). This PR corrects this incorrect rendering.