### PR TITLE
Example site: fix warning message

### DIFF
--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 


### PR DESCRIPTION
When previewing the example site, a warning is printed:

```
WARN 2022/03/02 21:41:22 The "twitter_simple" shortcode will soon require two named parameters: user and id.
```

By applying this PR fixes, we get rid of this warning.