### PR TITLE
[DEPRECATING] google_news

### DIFF
--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -1,5 +1,3 @@
-{{ template "_internal/google_news.html" . }}
-
 {{ template "_internal/schema.html" . }}
 
 {{ template "_internal/twitter_cards.html" . }}


### PR DESCRIPTION
To stop the warning of deprecated.
Based on this link:
https://github.com/gohugoio/hugo/issues/9172

#16 